### PR TITLE
代码重构前存档

### DIFF
--- a/B_Spline.py
+++ b/B_Spline.py
@@ -6,6 +6,12 @@ from matplotlib import pyplot as plt
 class BSpline:
 
     def calc(self, point, k=3, sample=100):
+        """
+        :param point: ctrl point
+        :param k: degrees
+        :param sample: Length of the output.
+        :return: B Spline curve witch is a list contain sequence of x,y
+        """
         ctr = np.array(point)
         x = ctr[:, 0]
         y = ctr[:, 1]

--- a/ffttest.py
+++ b/ffttest.py
@@ -1,0 +1,42 @@
+import numpy as np
+from scipy.fftpack import fft
+import matplotlib.pyplot as plt
+from B_Spline import BSpline
+from point import PointData
+from mysound import sound
+
+Fs = 10
+pp = PointData()
+pp.setStart(1.0)
+pp.setEnd(2.0)
+pp.setAnchors(0, 0.2, 2)
+pp.setAnchors(1, 0.3, -1)
+pp.setAnchors(2, 0.35, 6)
+pp.setAnchors(3, 0.5, 4)
+pp.setAnchors(4, 0.6, 0)
+pp.insert(0.9, -10)
+tmp = pp.getData()
+line = BSpline().calc(tmp, sample=Fs)
+x = tmp[:, 0]
+y = tmp[:, 1]
+sd = sound()
+line2 = sd.soundGen(line, Durtime=1, Fstimes=Fs)
+
+
+def FFT(Fs, data):
+    L = len(data)  # 信号长度
+    N = int(np.power(2, np.ceil(np.log2(L))))  # 下一个最近二次幂
+    FFT_y1 = np.abs(fft(data, N)) / L * 2  # N点FFT 变化,但处于信号长度
+    Fre = np.arange(int(N / 2)) * Fs / N  # 频率坐标
+    FFT_y1 = FFT_y1[range(int(N / 2))]  # 取一半
+    return Fre, FFT_y1
+
+
+plt.subplot(2, 1, 1)
+print(line2)
+plt.plot(line2)
+Fre, FFT_y1 = FFT(Fs, line2)
+plt.subplot(2, 1, 2)
+plt.plot(Fre, FFT_y1)
+plt.grid()
+plt.show()

--- a/mainUI.ui
+++ b/mainUI.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>600</height>
+    <height>605</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,19 +25,23 @@
     </property>
     <layout class="QVBoxLayout" name="verticalLayout">
      <item>
-      <widget class="QPushButton" name="pushButton">
-       <property name="text">
-        <string>PushButton</string>
-       </property>
+      <widget class="QComboBox" name="DominSelection">
+       <item>
+        <property name="text">
+         <string>Time Domin</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Frequency Domin</string>
+        </property>
+       </item>
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="draw">
-       <property name="text">
-        <string>draw</string>
-       </property>
-       <property name="autoDefault">
-        <bool>false</bool>
+      <widget class="QLineEdit" name="FreEdit">
+       <property name="mouseTracking">
+        <bool>true</bool>
        </property>
       </widget>
      </item>

--- a/mysound.py
+++ b/mysound.py
@@ -7,16 +7,23 @@ class sound:
     Fre = 440
     sd = []
 
-    def soundGen(self, sample, time, fs):
-        self.fs = fs
+    def soundGen(self, sample, Durtime, Fstimes):
+        """
+        :param sample: base sample signal
+        :param Durtime: Duration time
+        :param Fstimes: proportion between Frequency sample  and frequency
+        :return: output signal which is a sequence of repetitive sample
+        """
+        self.fs = self.Fre * Fstimes
         # x = sample[0]
         y = sample[1]
-        T = int(time * fs / (4 * len(y)))
+        T = int(Durtime * self.fs / (4 * len(y)))
         # 这里*4是因为在播放的时候转成bytes流播放，每一个数据转成32位字节，正好是1到4
         self.sd = []
         for i in range(T):
-            self.sd.append(y)
+            self.sd.extend(y)
         self.sd = np.array(self.sd)
+        return self.sd
 
     def setVolume(self, vloume):
         pass
@@ -34,6 +41,7 @@ class sound:
         stream.write(self.sd.tobytes())
         stream.stop_stream()
         stream.close()
+
 
 if __name__ == '__main__':
     x = np.linspace(0, 2*np.pi, 100)

--- a/point.py
+++ b/point.py
@@ -47,7 +47,34 @@ class PointData(EdgePoint, AnchorPoint):
         self.setEnd(0)
         for i in range(5):
             x = (0.2 + i / 5.0) * 0.8
-            self.setAnchors(i, x, 0)
+            super().setAnchors(i, x, 0)
+
+    def setAnchors(self, index, x, y):
+        """
+        rewrite steAanchors and limited bounds
+        :param index: index of point
+        :param x: x in axis
+        :param y: y in axis
+        :return: set x,y coordinates
+        """
+        bais = 0.01
+        if index <= 0:
+            left = self.start
+            right = self.anchors[index + 1]
+        elif index >= self.size() - 1:
+            left = self.anchors[index - 1]
+            right = self.end
+        else:
+            left = self.anchors[index - 1]
+            right = self.anchors[index + 1]
+        if x > right[0] - bais:
+            self.anchors[index][0] = right[0] - bais
+        elif x < left[0] + bais:
+            self.anchors[index][0] = left[0] + bais
+        else:
+            self.anchors[index][0] = x
+        self.anchors[index][1] = y
+        return [self.anchors[index][0], self.anchors[index][1]]
 
     def getData(self):
         tmp = [it for it in self.anchors]
@@ -56,7 +83,8 @@ class PointData(EdgePoint, AnchorPoint):
         return np.array(tmp)
 
     def size(self):
-        return len(self.anchors) + 1
+        return len(self.anchors)
+
 
 if __name__ == '__main__':
     pp = PointData()

--- a/test.py
+++ b/test.py
@@ -19,7 +19,7 @@ y = tmp[:, 1]
 
 
 sd = sound()
-sd.soundGen(line, fs=100*440, time=1)
+print(sd.soundGen(line, Fstimes=100, Durtime=1))
 sd.play()
 
 plt.plot(line[0], line[1])


### PR DESCRIPTION
现在UI类和myplot类耦合问题逐渐明显，随着功能的加入，绘图以及计算代码逐渐从UI类和myplot类中泄露出来，有必要进行一次代码整合，添加一个中间层，负责沟通绘画以及计算层。

值得说明的是，现在的绘画层，需要保留一部分计算的能力。这是因为需要myplot的获取鼠标动作。

- 本次重构内容：UI类与myplot类的解耦合
- 方法：添加中间层

### 施工前计划细节：

- 将UI类中的所有回调函数句柄（Handle）移交给中间层目前包括：
`__soundPlayHandle
__FreEditHandle
__DominSelectionHandle`
- 将myplot 以及 mysound实例化内容交给中间层
- 将新增功能（“显示频谱图”的计算内容）交给中间层